### PR TITLE
Menu support for older browsers

### DIFF
--- a/menu/style.css
+++ b/menu/style.css
@@ -7,7 +7,13 @@
   height: 100%;
   z-index: 99999;
   transform: translateX(-312px);
+  -webkit-transform: translateX(-312px);
+  -moz-transform: translateX(-312px);
+  -o-transform: translateX(-312px);
   transition-duration: 280ms;
+  -webkit-transition-duration: 280ms;
+  -moz-transition-duration: 280ms;
+  -o-transition-duration: 280ms;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
   overflow: auto;
 }
@@ -19,10 +25,16 @@
   right: 0;
   left: auto;
   transform: translateX(105%);
+  -webkit-transform: translateX(105%);
+  -moz-transform: translateX(105%);
+  -o-transform: translateX(105%);
 }
 /*Set a menu is open.*/
 .menu.open {
   transform: translateX(0px);
+  -webkit-transform: translateX(0px);
+  -moz-transform: translateX(0px);
+  -o-transform: translateX(0px);
 }
 .menu.menu-right.open {
   margin-left: -312px;
@@ -34,7 +46,13 @@
     width: 264px;
     box-shadow:none;
     transition-duration: 0ms;
+    -webkit-transition-duration: 0ms;
+    -moz-transition-duration: 0ms;
+    -o-transition-duration: 0ms;
     transform: translateX(-264px);
+    -webkit-transform: translateX(-264px);
+    -moz-transform: translateX(-264px);
+    -o-transform: translateX(-264px);
     box-shadow: none;
 }
 .platform-ios .menu.cover {
@@ -42,24 +60,42 @@
 }
 .platform-ios .menu.menu-right {
   transform: translateX(105%);
+  -webkit-transform: translateX(105%);
+  -moz-transform: translateX(105%);
+  -o-transform: translateX(105%);
   transition-duration: 0ms;
+  -webkit-transition-duration: 0ms;
+  -moz-transition-duration: 0ms;
+  -o-transition-duration: 0ms;
 }
 .platform-ios .menu.open {
   transform: translateX(-264px);
+  -webkit-transform: translateX(-264px);
+  -moz-transform: translateX(-264px);
+  -o-transform: translateX(-264px);
   margin-left: -1px;
 }
 .platform-ios .menu.menu-right.open {
   margin-left: -263px;
   transform:none;
+  -webkit-transform: none;
+  -moz-transform: none;
+  -o-transform: none;
   box-shadow: 0 0 10px rgba(0, 0, 0, 0.25);
 }
 .platform-ios .body,
 .platform-ios body {
   transition-duration: 0ms;
+  -webkit-transition-duration: 0ms;
+  -moz-transition-duration: 0ms;
+  -o-transition-duration: 0ms;
 }
 .platform-ios .body.side-menu,
 .platform-ios.side-menu {
     transform: translateX(264px);
+    -webkit-transform: translateX(264px);
+    -moz-transform: translateX(264px);
+    -o-transform: translateX(264px);
     border-left: 1px solid rgba(0, 0, 0, 0.15);
     overflow: hidden;
 }


### PR DESCRIPTION
On my phone (Android 4.4.2) menu was still showing and I found that -webkit-... fix the issue. I rather added -moz-... and -o-... for 100% support.