### PR TITLE
Progress circle and semicircle fix

### DIFF
--- a/progress-circle/script.js
+++ b/progress-circle/script.js
@@ -108,7 +108,7 @@ window.ProgressCircle = {
           circle.path.setAttribute('stroke', state.color);
           circle.path.setAttribute('stroke-width', state.width);
 
-          var valueInner = Math.round(circle.value() * 100);
+          var valueInner = Math.round(circle.value() * config.maxValue);
           if(config.showValue){
             valueInner = config.value
           }
@@ -136,12 +136,17 @@ window.ProgressCircle = {
       });
       elm.progressCircle.update = function(v){
         var valueBar = 0;
-        if(v < 100){
-          valueBar = Number("0." + v.toString().replace('.',''));
+        if(v < config.maxValue && v >= 0) {
+          valueBar = v/config.maxValue;
+        } else if(v < 0) {
+          console.error("Value for progress circle is too small. (Requested value is "+v+")");
+        } else {
+          console.error("Value for progress circle is too high. Maximum is "+config.maxValue+" and requested value is "+v+". (Value set to maximum for now.)")
+          valueBar=1;
         }
         this.bar.animate(valueBar);
       }
-      elm.progressCircle.update((config.value/config.maxValue)*100);
+      elm.progressCircle.update(config.value);
     }
   }
 }

--- a/progress-circle/script.js
+++ b/progress-circle/script.js
@@ -136,7 +136,7 @@ window.ProgressCircle = {
       });
       elm.progressCircle.update = function(v){
         var valueBar = 0;
-        if(v < config.maxValue && v >= 0) {
+        if(v <= config.maxValue && v >= 0) {
           valueBar = v/config.maxValue;
         } else if(v < 0) {
           console.error("Value for progress circle is too small. (Requested value is "+v+")");

--- a/progress-semicircle/script.js
+++ b/progress-semicircle/script.js
@@ -131,7 +131,7 @@ window.ProgressSemicircle = {
       });
       elm.progressSemicircle.update = function(v){
         var valueBar = 0;
-        if(v < config.maxValue && v >= 0) {
+        if(v <= config.maxValue && v >= 0) {
           valueBar = v/config.maxValue;
         } else if(v < 0) {
           console.error("Value for progress semicircle is too small. (Requested value is "+v+")");

--- a/progress-semicircle/script.js
+++ b/progress-semicircle/script.js
@@ -105,7 +105,7 @@ window.ProgressSemicircle = {
           circle.path.setAttribute('stroke', state.color);
           circle.path.setAttribute('stroke-width', state.width);
 
-          var valueInner = Math.round(circle.value() * 100);
+          var valueInner = Math.round(circle.value() * config.maxValue);
           var valueText = '';
           if(config.title){
             var style = 'style="';
@@ -131,12 +131,17 @@ window.ProgressSemicircle = {
       });
       elm.progressSemicircle.update = function(v){
         var valueBar = 0;
-        if(v < 100){
-          valueBar = Number("0." + v.toString().replace('.',''));
+        if(v < config.maxValue && v >= 0) {
+          valueBar = v/config.maxValue;
+        } else if(v < 0) {
+          console.error("Value for progress semicircle is too small. (Requested value is "+v+")");
+        } else {
+          console.error("Value for progress semicircle is too high. Maximum is "+config.maxValue+" and requested value is "+v+". (Value set to maximum for now.)")
+          valueBar=1;
         }
         this.bar.animate(valueBar);
       }
-      elm.progressSemicircle.update((config.value/config.maxValue)*100);
+      elm.progressSemicircle.update(config.value);
     }
   }
 }


### PR DESCRIPTION
Added error message when progress circle value overflow or underflow. Also fixing error when value <10 is requested, then it was multiplied by 10. There is too fix for maxValue, because it wasn't actually working before.