### PR TITLE
Bugfix for progress circle and semicircle

### DIFF
--- a/progress-circle/script.js
+++ b/progress-circle/script.js
@@ -15,7 +15,7 @@ window.ProgressCircle = {
       var config = {};
       config.value = Number(progress[i].getAttribute('value'));
       config.maxValue = Number(progress[i].getAttribute('maxValue')) || 100;
-      config.showValue = Number(progress[i].getAttribute('showValue')) || false;
+      config.showValue = progress[i].getAttribute('showValue')==='1' || progress[i].getAttribute('showValue')==='true' || false;
       config.title = progress[i].getAttribute('title') || '';
       config.subTitle = progress[i].getAttribute('subTitle') || '';
       config.text = progress[i].getAttribute('text') || '';
@@ -46,6 +46,9 @@ window.ProgressCircle = {
       if(!elm.classList.contains('progress-circle')){
         elm.classList.add('progress-circle-js')
       }
+      config.value = config.value || 0;
+      config.maxValue = config.maxValue || 100;
+      config.showValue = config.showValue || false;
       config.title = config.title || '';
       config.subTitle = config.subTitle || '';
       config.text = config.text || '';
@@ -139,9 +142,9 @@ window.ProgressCircle = {
         if(v <= config.maxValue && v >= 0) {
           valueBar = v/config.maxValue;
         } else if(v < 0) {
-          console.error("Value for progress circle is too small. (Requested value is "+v+")");
+          console.warn("Value for progress circle is too small. (Requested value is "+v+")");
         } else {
-          console.error("Value for progress circle is too high. Maximum is "+config.maxValue+" and requested value is "+v+". (Value set to maximum for now.)")
+          console.warn("Value for progress circle is too high. Maximum is "+config.maxValue+" and requested value is "+v+". (Value set to maximum for now.)")
           valueBar=1;
         }
         this.bar.animate(valueBar);

--- a/progress-semicircle/script.js
+++ b/progress-semicircle/script.js
@@ -47,6 +47,8 @@ window.ProgressSemicircle = {
       if(!elm.classList.contains('progress-semicircle')){
         elm.classList.add('progress-semicircle-js')
       }
+      config.value = config.value || 0;
+      config.maxValue = config.maxValue || 100;
       config.title = config.title || '';
       config.subTitle = config.subTitle || '';
       config.text = config.text || '';
@@ -134,9 +136,9 @@ window.ProgressSemicircle = {
         if(v <= config.maxValue && v >= 0) {
           valueBar = v/config.maxValue;
         } else if(v < 0) {
-          console.error("Value for progress semicircle is too small. (Requested value is "+v+")");
+          console.warn("Value for progress semicircle is too small. (Requested value is "+v+")");
         } else {
-          console.error("Value for progress semicircle is too high. Maximum is "+config.maxValue+" and requested value is "+v+". (Value set to maximum for now.)")
+          console.warn("Value for progress semicircle is too high. Maximum is "+config.maxValue+" and requested value is "+v+". (Value set to maximum for now.)")
           valueBar=1;
         }
         this.bar.animate(valueBar);


### PR DESCRIPTION
I am fixing bug, where max value and value wasn't initialized when calling create function and also few others uninitialized variables. (This bug can be seen at second example of progress circle https://mobileui.github.io/#progress-circle) Also I noticed that showValue was casted to number without any reason, so I  it is now checked for value "1" or "true" instead.
I also deciced, that I was too strict when in last pull request I added error messages, that values are out of range, so I just changed it to show warning message.